### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Potential fix for [https://github.com/sectsect/use-placeholder-path/security/code-scanning/1](https://github.com/sectsect/use-placeholder-path/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the following permissions are needed:
- `contents: read` for accessing repository files.
- `pull-requests: write` for creating release pull requests.
- `packages: write` for publishing packages to npm.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`release`) in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
